### PR TITLE
Add option to hook into module internals

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,21 +37,31 @@ hook(['express', 'mongodb'], function (exports, name, basedir) {
 The require-in-the-middle module exposes a single function:
 
 ```js
-function ([modules, ]onrequire) {}
+function ([modules][, options], onrequire) {}
 ```
 
-You can optionally supply an array of module names as the first argument
-to limit which modules will trigger a call of the `onrequire` callback.
+- `modules` <string[]> An optional array of module names to limit which modules
+  trigger a call of the `onrequire` callback. If specified, this must be the
+  first argument.
+- `options` <Object> An optional object containing fields that change when the
+  `onrequire` callback is called. If specified, this must be the second
+  argument.
+  - `options.internals` <boolean> Specifies whether `onrequire` should be called
+    when module-internal files are loaded; defaults to `false`.
+- `onrequire` <Function> The function to call when a module is required.
 
 Supply a callback function as the last argument. This function will be
 called the first time a module is required. The `onrequire` function is
 called with three arguments:
 
-- `exports` - The value of the `module.exports` property that would
-  normally be exposed by the required module
-- `name` - The name of the module being required
-- `basedir` - The directory of the where the module is located (will be
-  `undefined` if core module)
+- `exports` <Object> The value of the `module.exports` property that would
+  normally be exposed by the required module.
+- `name` <string> The name of the module being required. If `options.internals`
+  was set to `true`, the path of module-internal files that are loaded
+  (relative to `basedir`) will be appended to the module name, separated by
+  `path.sep`.
+- `basedir` <string> The directory where the module is located, or `undefined`
+  for core modules.
 
 Return the value you want the module to expose (normally the `exports`
 argument).

--- a/test/node_modules/internal/index.js
+++ b/test/node_modules/internal/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/a') + ', ' + require('./lib/b')

--- a/test/node_modules/internal/lib/a.js
+++ b/test/node_modules/internal/lib/a.js
@@ -1,0 +1,1 @@
+module.exports = 'Hello ' + require('./b')

--- a/test/node_modules/internal/lib/b.js
+++ b/test/node_modules/internal/lib/b.js
@@ -1,0 +1,2 @@
+require('./a')
+module.exports = 'world'

--- a/test/test.js
+++ b/test/test.js
@@ -103,3 +103,21 @@ test('circular', function (t) {
 
   t.deepEqual(require('./node_modules/circular'), { foo: 1 })
 })
+
+test('internal', function (t) {
+  t.plan(8)
+
+  var loadedModules = []
+  hook({
+    modules: ['internal'],
+    internals: true
+  }, function (exports, name, basedir) {
+    t.true(name.match(/^internal/))
+    t.true(basedir.match(/test\/node_modules\/internal$/))
+    loadedModules.push(name)
+    return exports
+  })
+
+  t.equal(require('./node_modules/internal'), 'Hello world, world')
+  t.deepEqual(loadedModules, ['internal/lib/b.js', 'internal/lib/a.js', 'internal'])
+})

--- a/test/test.js
+++ b/test/test.js
@@ -108,8 +108,7 @@ test('internal', function (t) {
   t.plan(8)
 
   var loadedModules = []
-  hook({
-    modules: ['internal'],
+  hook(['internal'], {
     internals: true
   }, function (exports, name, basedir) {
     t.true(name.match(/^internal/))


### PR DESCRIPTION
Thanks for the fantastic module!

Given that the purpose of this module is for monkeypatching, it would be useful to be able to monkeypatch module internals as well. This PR adds that by turning the first argument to `hook` into an options object that contains fields for both a list of modules, and a flag to enable calling the hook on module internals. Existing behavior should be preserved exactly.

Example: https://gist.github.com/kjin/cc7eb513fc389882afce978d9673e343