### PR TITLE
Make cache value replaceable

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,9 +52,14 @@ module.exports = function hook (modules, onrequire) {
       if (res !== filename) return exports // abort if not main module file
     }
 
-    if (hook.cache[filename]) return exports // abort if module have already been processed
-    hook.cache[filename] = exports
+    // only call onrequire the first time a module is loaded
+    if (!hook.cache.hasOwnProperty(filename)) {
+      // ensure that the cache entry is assigned a value before calling
+      // onrequire, in case calling onrequire requires the same module.
+      hook.cache[filename] = exports
+      hook.cache[filename] = onrequire(exports, name, basedir)
+    }
 
-    return onrequire(exports, name, basedir)
+    return hook.cache[filename]
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -93,6 +93,19 @@ test('cache', function (t) {
   t.end()
 })
 
+test('replacement value', function (t) {
+  var replacement = {}
+
+  hook(['url'], function (exports, name, basedir) {
+    return replacement
+  })
+
+  t.deepEqual(require('url'), replacement)
+  t.deepEqual(require('url'), replacement)
+
+  t.end()
+})
+
 test('circular', function (t) {
   t.plan(2)
 


### PR DESCRIPTION
Right now, if the `onrequire` hook returns a replacement value for a module (which I assume is allowable behavior), this replacement value won't get stored in the cache -- the original value will be stored instead. This means that requiring that module twice will give different results.

I changed this so that the replacement value gets cached instead, and added a test (which would fail without this change).